### PR TITLE
device.mk: update to use aosp_optee.mk in optee_os

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -62,6 +62,12 @@ PRODUCT_PACKAGES += libion
 PRODUCT_PACKAGES += gralloc.hikey
 
 
+OPTEE_PLATFORM ?= hikey
+OPTEE_CFG_ARM64_CORE ?= y
+OPTEE_TA_TARGETS ?= ta_arm64
+OPTEE_OS_DIR ?= optee/optee_os
+BUILD_OPTEE_MK := $(OPTEE_OS_DIR)/mk/aosp_optee.mk
+
 PRODUCT_PACKAGES += libteec \
 					tee-supplicant \
 					tee_helloworld \


### PR DESCRIPTION
this change needs the merge of here:
https://github.com/OP-TEE/optee_os/pull/828

Signed-off-by: Yongqin Liu yongqin.liu@linaro.org
