### PR TITLE
Add SELinux support for tee-supplicant

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -55,6 +55,10 @@ ENABLE_CPUSETS := true
 
 BOARD_SEPOLICY_DIRS := device/linaro/hikey/sepolicy
 
+BOARD_SEPOLICY_UNION += \
+    file_contexts \
+    sepolicy.te
+
 ifeq ($(HOST_OS), linux)
 ifeq ($(TARGET_SYSTEMIMAGES_USE_SQUASHFS), true)
 BOARD_SYSTEMIMAGE_FILE_SYSTEM_TYPE := squashfs

--- a/init.hikey.rc
+++ b/init.hikey.rc
@@ -90,9 +90,10 @@ service uim /system/bin/uim
     user root
     oneshot
 
-service tee-supplicant /system/bin/tee-supplicant
+service tee_supplicant /system/bin/tee-supplicant
     class main
     user root
+    group shell
     oneshot
 
 service wpa_supplicant /system/bin/wpa_supplicant \

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -4,3 +4,6 @@
 /dev/dri/card0         u:object_r:gpu_device:s0
 /dev/hci_tty           u:object_r:hci_attach_dev:s0
 /system/bin/uim        u:object_r:hci_attach_exec:s0
+/dev/tee[0-9]*              u:object_r:tee_device:s0
+/dev/teepriv[0-9]*          u:object_r:tee_device:s0
+/system/bin/tee-supplicant  u:object_r:tee_exec:s0

--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -1,4 +1,6 @@
 # init.hikey.usb.rc writes to /config/* to set up USB
 allow init configfs:dir create_file_perms;
 allow init configfs:file write;
-allow init configfs:lnk_file create;
+allow tee system_data_file:dir write;
+allow tee system_data_file:dir add_name;
+allow tee system_data_file:dir create;

--- a/ueventd.hikey.rc
+++ b/ueventd.hikey.rc
@@ -1,3 +1,5 @@
 /dev/hci_tty     0666 root root
 /dev/ttyAMA1     0660 bluetooth net_bt_stack
 /dev/mali        0666 system graphics
+/dev/tee0        0660   system     drmrpc
+/dev/teepriv0    0660   system     drmrpc


### PR DESCRIPTION
Reusing the existing domain for tee defined
in system/sepolicy.

Signed-off-by: Zoltan Kuscsik zoltan.kuscsik@linaro.org
